### PR TITLE
Controle que l'email n'existe pas déjà avant l'inscription

### DIFF
--- a/routes/auth-router.ts
+++ b/routes/auth-router.ts
@@ -44,9 +44,13 @@ authRouter.post("/subscribe", async function (req, res) {
         phoneNumber,
         typeId
     });
+    if (user === null){
+        res.status(400).end();
+        return;
+    }
     //connexion de l'utilisateur
     const session = await authController.login(mail, password);
-    if (user !== null && session !== null) {
+    if (session !== null) {
         res.status(201);
         res.json({user, session});
     } else {


### PR DESCRIPTION
J'ai fait le controle + petite modif : 
- Lorsque que l'inscription échouait parce que l'email était déjà pris, ça créé quand même une nouvelle session avec le compte déjà existant. J'ai changé vite fait le code pour que ça ne fasse plus ce problème.

J'ai aussi gardé l'ancienne façon de garder des logs comme ça ça nique pas le travail de Arthur sur le refacto